### PR TITLE
优化日志及输出模型信息

### DIFF
--- a/launch_camoufox.py
+++ b/launch_camoufox.py
@@ -96,6 +96,18 @@ def setup_launcher_logging(log_level=logging.INFO):
     launcher_logger.propagate = False
 
     # 1. Rotating File Handler (使用详细格式)
+    # 确保每次启动时日志文件都是全新的。
+    # RotatingFileHandler 的 mode='w' 应该在初始化时截断文件，
+    # 但为了应对可能的句柄未释放或平台特定行为导致追加的问题，
+    # 我们在此显式尝试删除旧文件。
+    if os.path.exists(LOG_FILE_PATH):
+        try:
+            os.remove(LOG_FILE_PATH)
+            # 这条诊断信息会输出到 stderr，因为它在文件日志处理器设置之前。
+            print(f"INFO: 旧的日志文件 {LOG_FILE_PATH} 已在日志设置前被移除。", file=sys.stderr)
+        except OSError as e:
+            # 如果删除失败（例如，文件被锁定），则依赖 RotatingFileHandler 的 mode='w'。
+            print(f"警告: 尝试移除旧的日志文件 {LOG_FILE_PATH} 失败: {e}。将依赖 mode='w' 进行截断。", file=sys.stderr)
     file_handler = logging.handlers.RotatingFileHandler(
         LOG_FILE_PATH, maxBytes=2*1024*1024, backupCount=3, encoding='utf-8', mode='w' # 文件小一点
     )

--- a/launch_camoufox.py
+++ b/launch_camoufox.py
@@ -97,7 +97,7 @@ def setup_launcher_logging(log_level=logging.INFO):
 
     # 1. Rotating File Handler (使用详细格式)
     file_handler = logging.handlers.RotatingFileHandler(
-        LOG_FILE_PATH, maxBytes=2*1024*1024, backupCount=3, encoding='utf-8' # 文件小一点
+        LOG_FILE_PATH, maxBytes=2*1024*1024, backupCount=3, encoding='utf-8', mode='w' # 文件小一点
     )
     file_handler.setFormatter(file_log_formatter) # <-- 使用详细格式
     launcher_logger.addHandler(file_handler)

--- a/launch_camoufox.py
+++ b/launch_camoufox.py
@@ -355,6 +355,7 @@ def start_main_server(ws_endpoint, launch_mode, server_port, active_auth_json=No
 
     env = os.environ.copy()
     env['CAMOUFOX_WS_ENDPOINT'] = ws_endpoint
+    env['PYTHONIOENCODING'] = 'utf-8' # 确保输出使用 UTF-8
     env['LAUNCH_MODE'] = launch_mode # 传递启动模式
     if active_auth_json:
         env['ACTIVE_AUTH_JSON_PATH'] = active_auth_json # 传递激活的JSON路径
@@ -628,12 +629,22 @@ if __name__ == "__main__":
             'encoding': 'utf-8', # 显式指定编码
             'errors': 'ignore' # 忽略解码错误
         }
+        # 为子进程准备环境，确保 UTF-8 输出
+        child_env_debug = os.environ.copy()
+        child_env_debug['PYTHONIOENCODING'] = 'utf-8'
+        popen_kwargs['env'] = child_env_debug
+
         if sys.platform != "win32":
             popen_kwargs['start_new_session'] = True
         else:
-            popen_kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+            # 确保子进程在后台运行且无窗口
+            popen_kwargs['creationflags'] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW
 
         camoufox_proc = subprocess.Popen(cmd, **popen_kwargs)
+
+
+
+
 
         print(f"   Camoufox 子进程已启动 (PID: {camoufox_proc.pid})。等待 WebSocket 端点输出 (最多 {ENDPOINT_CAPTURE_TIMEOUT} 秒)...", flush=True)
 
@@ -750,10 +761,16 @@ if __name__ == "__main__":
                 'encoding': 'utf-8',
                 'errors': 'ignore'
             }
+            # 为子进程准备环境，确保 UTF-8 输出
+            child_env_headless = os.environ.copy()
+            child_env_headless['PYTHONIOENCODING'] = 'utf-8'
+            popen_kwargs['env'] = child_env_headless
+
             if sys.platform != "win32":
                 popen_kwargs['start_new_session'] = True
             else:
-                popen_kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+                # 确保子进程在后台运行且无窗口
+                popen_kwargs['creationflags'] = subprocess.DETACHED_PROCESS | subprocess.CREATE_NO_WINDOW
 
             camoufox_proc = subprocess.Popen(cmd, **popen_kwargs)
             print(f"   Camoufox 子进程已启动 (PID: {camoufox_proc.pid})。等待 WebSocket 端点输出 (最多 {ENDPOINT_CAPTURE_TIMEOUT} 秒)...", flush=True)

--- a/server.py
+++ b/server.py
@@ -241,7 +241,7 @@ def setup_logging(log_level=logging.INFO, redirect_print=False): # <-- 默认改
 
     # 1. Rotating File Handler (使用详细格式)
     file_handler = logging.handlers.RotatingFileHandler(
-        LOG_FILE_PATH, maxBytes=5*1024*1024, backupCount=5, encoding='utf-8'
+        LOG_FILE_PATH, maxBytes=5*1024*1024, backupCount=5, encoding='utf-8', mode='w'
     )
     file_handler.setFormatter(file_log_formatter)
     root_logger.addHandler(file_handler)
@@ -716,6 +716,7 @@ async def _initialize_page_logic(browser: AsyncBrowser):
             # 获取模型名称
             model_name = await model_wrapper_locator.inner_text()
             print(f"-> 🤖 当前模型: {model_name}")
+            logger.info(f"(🤖 当前模型) {model_name}")
             result_page = found_page
             result_ready = True
             print(f"✅ 页面逻辑初始化成功。")

--- a/server.py
+++ b/server.py
@@ -710,6 +710,12 @@ async def _initialize_page_logic(browser: AsyncBrowser):
             await expect_async(input_wrapper_locator).to_be_visible(timeout=35000)
             await expect_async(found_page.locator(INPUT_SELECTOR)).to_be_visible(timeout=10000)
             print("-> ✅ 核心输入区域可见。")
+            # 使用更精确的选择器定位模型名称元素
+            # 添加first()确保只选择第一个匹配的元素，避免严格模式违规
+            model_wrapper_locator = found_page.locator('#mat-select-value-0 mat-select-trigger').first
+            # 获取模型名称
+            model_name = await model_wrapper_locator.inner_text()
+            print(f"-> 🤖 当前模型: {model_name}")
             result_page = found_page
             result_ready = True
             print(f"✅ 页面逻辑初始化成功。")

--- a/server.py
+++ b/server.py
@@ -240,6 +240,15 @@ def setup_logging(log_level=logging.INFO, redirect_print=False): # <-- 默认改
     root_logger.setLevel(log_level) # <-- Revert back to INFO (or original log_level)
 
     # 1. Rotating File Handler (使用详细格式)
+    # 确保每次启动时 app.log 文件都是全新的
+    if os.path.exists(LOG_FILE_PATH):
+        try:
+            os.remove(LOG_FILE_PATH)
+            # 诊断信息输出到原始 stderr
+            print(f"INFO: 旧的日志文件 {LOG_FILE_PATH} 已在日志设置前被移除。", file=sys.__stderr__)
+        except OSError as e:
+            # 删除失败则依赖 mode='w'
+            print(f"警告: 尝试移除旧的日志文件 {LOG_FILE_PATH} 失败: {e}。将依赖 mode='w' 进行截断。", file=sys.__stderr__)
     file_handler = logging.handlers.RotatingFileHandler(
         LOG_FILE_PATH, maxBytes=5*1024*1024, backupCount=5, encoding='utf-8', mode='w'
     )

--- a/start.py
+++ b/start.py
@@ -269,6 +269,8 @@ def main():
     # 3. 为子进程准备环境
     print("\n--- 步骤 2: 准备环境 ---")
     child_env = copy.deepcopy(os.environ)
+    # 确保 PYTHONIOENCODING 环境变量设置为 utf-8, 确保输出不乱码
+    child_env['PYTHONIOENCODING'] = 'utf-8'
     if proxy_address:
         child_env["HTTP_PROXY"] = proxy_address
         child_env["HTTPS_PROXY"] = proxy_address

--- a/start.py
+++ b/start.py
@@ -287,6 +287,16 @@ def main():
     print("\n--- 步骤 3: 启动主程序 (无头模式) ---")
     script_filename = "launch_camoufox.py"
     python_executable = sys.executable # 使用运行此脚本的同一个 Python 解释器
+    if sys.platform == "win32":
+        # 尝试找到 pythonw.exe。pythonw.exe 是一个不打开控制台窗口的 python 版本。
+        _pythonw_candidate = os.path.join(os.path.dirname(sys.executable), "pythonw.exe")
+        if os.path.exists(_pythonw_candidate):
+            print(f"  提示: 在 Windows 上，将尝试使用 '{_pythonw_candidate}' 启动子进程以确保无窗口。")
+            python_executable = _pythonw_candidate
+        else:
+            print(f"  警告: 未在 '{os.path.dirname(sys.executable)}' 目录下找到 pythonw.exe。")
+            print(f"        将继续使用默认的 '{sys.executable}'。如果子进程仍然显示窗口，这可能是原因之一。")
+            print(f"        确保 pythonw.exe 与 python.exe 在同一目录通常可以解决此问题。")
 
     # --- 构造 script_to_run 的绝对路径 ---
     script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -341,7 +351,9 @@ def main():
         print("--------------------------")
 
     # 可选：如果希望启动器窗口停留一会，可以取消下面这行的注释
-    input("按回车键退出此启动器脚本...")
+    # input("按回车键退出此启动器脚本...") # 注释掉此行，使启动器在启动子进程后自动退出
+    print("启动器任务完成，将在几秒后自动退出...")
+    time.sleep(3) # 短暂延迟，让用户有机会看到消息
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
启动时显式删除旧日志文件以确保全新日志，将 RotatingFileHandler 的文件模式改为 'w'，以确保每次启动时日志文件从新开始写入。同时，在页面逻辑初始化时添加模型名称的日志记录，以便更好地跟踪和调试。

改进子进程启动逻辑和页面元素选择器
在 Windows 上，使用 pythonw\.exe 启动子进程以避免显示控制台窗口，并确保子进程在后台运行。同时，在 server\.py 中优化模型名称元素的选择器，避免严格模式违规。此外，确保所有子进程输出使用 UTF-8 编码。