### PR TITLE
Add AIstudioProxyAPIHelper support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-fastapi
-uvicorn[standard]
-playwright
-camoufox[geoip]
-pydantic 
+fastapi~=0.115.12
+uvicorn[standard]~=0.34.2
+playwright~=1.52.0
+camoufox[geoip]~=0.4.11
+pydantic~=2.11.4
+aiohttp~=3.11.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-fastapi~=0.115.12
-uvicorn[standard]~=0.34.2
-playwright~=1.52.0
-camoufox[geoip]~=0.4.11
-pydantic~=2.11.4
+fastapi
+uvicorn[standard]
+playwright
+camoufox[geoip]
+pydantic
 aiohttp~=3.11.18

--- a/server.py
+++ b/server.py
@@ -1029,7 +1029,6 @@ async def signal_camoufox_shutdown():
 # --- Lifespan Context Manager (负责初始化和清理) ---
 @asynccontextmanager
 async def lifespan(app_param: FastAPI): # app_param 未使用
-    global STREAM_HELPER
     global playwright_manager, browser_instance, page_instance, worker_task
     global is_playwright_ready, is_browser_connected, is_page_ready, is_initializing
     global logger, log_ws_manager, model_list_fetch_event, current_ai_studio_model_id, excluded_model_ids


### PR DESCRIPTION
Sorry for my Python code; I haven't written Python in about 12 years.

I added code to support [AIstudioProxyAPIHelper](https://github.com/luispater/AIstudioProxyAPIHelper)

It's a MITM (Man-in-the-Middle) proxy server designed for AIstudioProxyAPI.

I created the Helper to sniff AI Studio responses, parse the response data, and convert it to an OpenAI Compatibility response format.

So, AIstudioProxyAPI can use this helper to get AI Studio responses in real-time, making it unnecessary to wait for the AI Studio UI anymore. And now, AIstudioProxyAPI can get reason data from AI Studio.

It also supports a secondary proxy for the Great Firewall.