### PR TITLE
fix:优化流式数据超时处理，增加错误日志记录并调整超时阈值

### DIFF
--- a/server.py
+++ b/server.py
@@ -1792,8 +1792,11 @@ async def use_stream_response() -> AsyncGenerator[Any, None]:
         except:
             total_empty = total_empty + 1
 
-        if total_empty > 150:
-            raise Exception("获得流式数据超时")
+        if total_empty > 1500:
+            # raise Exception("获得流式数据超时")
+            logger.error("获得流式数据超时")
+            yield {"done": True,"reason": "","body": ""}
+            return
 
         time.sleep(0.1)
 


### PR DESCRIPTION
issue: #108 
修复方案:
```
diff --git a/server.py b/server.py
index db5c2f5..9a958a2 100644
--- a/server.py
+++ b/server.py
@@ -1792,8 +1792,11 @@ async def use_stream_response() -> AsyncGenerator[Any, None]:
         except:
             total_empty = total_empty + 1

-        if total_empty > 150:
-            raise Exception("获得流式数据超时")
+        if total_empty > 1500:
+            # raise Exception("获得流式数据超时")
+            logger.error("获得流式数据超时")
+            yield {"done": True,"reason": "","body": ""}
+            return

         time.sleep(0.1)
```
粗暴的增大超时阈值,粗暴的手写假数据,以返回结束标记,终止流式输出,让流式生成器返回完成信号,以继续任务队列.
不知道是否有更优雅的方案👀