### PR TITLE
Dev

### DIFF
--- a/server.py
+++ b/server.py
@@ -1797,7 +1797,7 @@ async def use_stream_response() -> AsyncGenerator[Any, None]:
         except:
             total_empty = total_empty + 1
 
-        if total_empty > 150:
+        if total_empty > 300:
             # raise Exception("获得流式数据超时")
             logger.error("获得流式数据超时")
             yield {"done": True,"reason": "","body": ""}


### PR DESCRIPTION
简单修复因用户手动中断请求后,之后的所有回复错位的问题.
方案:
在释放处理锁之前,此时如果队列中有数据的话,肯定是不要的,就全消耗掉.
server.py:1734-1737
```
            # 清空流式队列缓存
            logger.info(f"[{req_id}] (Worker) 尝试清空流式队列缓存...")
            await clear_stream_queue()   
            logger.info(f"[{req_id}] (Worker) 释放处理锁。")
```
简单的清理函数
server.py:1807-1818
```
async def clear_stream_queue():
    while True:
        try:
            data_chunk = await asyncio.to_thread(STREAM_QUEUE.get_nowait)
            # logger.info(f"清空流式队列缓存，丢弃数据: {data_chunk}")
        except queue.Empty:
            logger.info("流式队列已清空 (捕获到 queue.Empty)。")
            break
        except Exception as e:
            logger.error(f"清空流式队列时发生意外错误: {e}", exc_info=True)
            break
    logger.info("流式队列缓存清空完毕。")
```
问题:
现在用户手动中断,流式其实会走到超时处理那里,将上个提交随便写的但太长的阈值从1500回调到300
server.py:1800-1804
```
        if total_empty > 300:
            # raise Exception("获得流式数据超时")
            logger.error("获得流式数据超时")
            yield {"done": True,"reason": "","body": ""}
            return
```
但其实应该按照群里大佬说的,如果用户取消任务,流式也应该停.
然后UI应该点击停止按钮,停止AI回复.再消耗掉多余的流式数据.
但先简单处理下,等群主定夺最终方案,群主还得重构server.py不是,就先不给server.py添砖加瓦了(懒).