### PR TITLE
docker相关修改

### DIFF
--- a/docker/README-Docker.md
+++ b/docker/README-Docker.md
@@ -28,9 +28,9 @@
 要构建 Docker 镜像，请在项目根目录下打开终端或命令行界面，然后执行以下命令：
 
 ```bash
-# 方法 1: 使用 docker-compose (推荐)
+# 方法 1: 使用 docker compose (推荐)
 cd docker
-docker-compose build
+docker compose build
 
 # 方法 2: 直接使用 docker build (在项目根目录执行)
 docker build -f docker/Dockerfile -t ai-studio-proxy:latest .
@@ -55,19 +55,19 @@ docker build -f docker/Dockerfile -t ai-studio-proxy:latest .
 Docker Compose 提供了更简洁的配置管理方式，特别适合使用 `.env` 文件：
 
 ```bash
-# 1. 准备配置文件 (在项目根目录)
-cp docker/.env.docker .env
+# 1. 准备配置文件 (进入 docker 目录)
+cp .env.docker .env
 # 编辑 .env 文件以适应您的需求
 
 # 2. 使用 Docker Compose 启动 (进入 docker 目录)
 cd docker
-docker-compose up -d
+docker compose up -d
 
 # 3. 查看日志
-docker-compose logs -f
+docker compose logs -f
 
 # 4. 停止服务
-docker-compose down
+docker compose down
 ```
 
 ### 方式 B: 使用 Docker 命令
@@ -329,7 +329,7 @@ docker run -d \
 现在 Docker 部署完全支持 `.env` 文件配置管理：
 
 ✅ **统一配置**: 主机和 Docker 环境使用相同的 `.env` 配置文件
-✅ **版本更新无忧**: `git pull` + `docker-compose up -d` 即可完成更新
+✅ **版本更新无忧**: `git pull` + `docker compose up -d` 即可完成更新
 ✅ **配置隔离**: 开发、测试、生产环境可使用不同的 `.env` 文件
 ✅ **安全性**: `.env` 文件不会被提交到版本控制
 
@@ -344,17 +344,17 @@ cp docker/.env.docker .env
 
 # 2. 启动服务
 cd docker
-docker-compose up -d
+docker compose up -d
 
 # 3. 版本更新
 cd ..  # 回到项目根目录
 git pull
 cd docker
-docker-compose up -d --build
+docker compose up -d --build
 
 # 4. 查看状态
-docker-compose ps
-docker-compose logs -f
+docker compose ps
+docker compose logs -f
 ```
 
 ### 配置文件说明

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,8 +14,8 @@
 ### 1. 准备配置文件
 
 ```bash
-# 在项目根目录执行
-cp docker/.env.docker .env
+# 进入 docker 目录
+cp .env.docker .env
 nano .env  # 编辑配置文件
 ```
 
@@ -26,10 +26,10 @@ nano .env  # 编辑配置文件
 cd docker
 
 # 构建并启动服务
-docker-compose up -d
+docker compose up -d
 
 # 查看日志
-docker-compose logs -f
+docker compose logs -f
 ```
 
 ### 3. 版本更新
@@ -41,7 +41,7 @@ git pull
 
 # 重新构建并启动
 cd docker
-docker-compose up -d --build
+docker compose up -d --build
 ```
 
 ## 📖 详细文档
@@ -52,25 +52,25 @@ docker-compose up -d --build
 
 ```bash
 # 查看服务状态
-docker-compose ps
+docker compose ps
 
 # 查看日志
-docker-compose logs -f
+docker compose logs -f
 
 # 停止服务
-docker-compose down
+docker compose down
 
 # 重启服务
-docker-compose restart
+docker compose restart
 
 # 进入容器
-docker-compose exec ai-studio-proxy /bin/bash
+docker compose exec ai-studio-proxy /bin/bash
 ```
 
 ## 🌟 主要优势
 
 - ✅ **统一配置**: 使用 `.env` 文件管理所有配置
-- ✅ **版本更新无忧**: `git pull` + `docker-compose up -d --build`
+- ✅ **版本更新无忧**: `git pull` + `docker compose up -d --build`
 - ✅ **环境隔离**: 容器化部署，避免环境冲突
 - ✅ **配置持久化**: 认证文件和日志持久化存储
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   ai-studio-proxy:
     build:
@@ -13,7 +11,7 @@ services:
       # 挂载认证文件目录 (必需)
       - ../auth_profiles:/app/auth_profiles
       # 挂载 .env 配置文件 (推荐)
-      - ../.env:/app/.env:ro
+      - ../docker/.env:/app/.env:ro
       # 挂载日志目录 (可选，用于持久化日志)
       - ../logs:/app/logs
       # 挂载自定义证书 (可选)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       # 挂载 .env 配置文件 (推荐)
       - ../docker/.env:/app/.env:ro
       # 挂载日志目录 (可选，用于持久化日志)
+      # 如果出现权限报错，需要修改日志目录权限 sudo chmod -R 777 ../logs
       - ../logs:/app/logs
       # 挂载自定义证书 (可选)
       # - ../certs:/app/certs:ro


### PR DESCRIPTION
本次提交更新了 Docker 设置以使用现代的 docker compose (V2) 语法
- 替换所有遗留的 `docker-compose` 命令的实例为 `docker compose`。
- 将 `.env` 文件位置从项目根目录移动到 `docker/` 目录，解决docker compose无法应用port部分环境变量的问题
- 更新 `docker-compose.yml` 文件以反映新的 `.env` 路径，并移除过时的 `version` 键。
- 根据新命令和文件结构调整 README 文件中的所有相关文档。