### PR TITLE
支持使用open ai格式思考控制，开启内置googlesearch功能

### DIFF
--- a/config/selectors.py
+++ b/config/selectors.py
@@ -42,3 +42,8 @@ MAT_CHIP_REMOVE_BUTTON_SELECTOR = 'mat-chip-set mat-chip-row button[aria-label*=
 TOP_P_INPUT_SELECTOR = 'div.settings-item-column:has(h3:text-is("Top P")) input[type="number"].slider-input'
 TEMPERATURE_INPUT_SELECTOR = 'div[data-test-id="temperatureSliderContainer"] input[type="number"].slider-input'
 USE_URL_CONTEXT_SELECTOR = 'button[aria-label="Browse the url context"]'
+SET_THINKING_BUDGET_TOGGLE_SELECTOR = 'button[aria-label="Toggle thinking budget between auto and manual"]'
+# Thinking budget slider input
+THINKING_BUDGET_INPUT_SELECTOR = 'xpath=//div[contains(@class, "settings-item") and .//p[normalize-space()="Set thinking budget"]]/following-sibling::div[contains(@class, "item-input")]//input[@type="number"]'
+# --- Google Search Grounding ---
+GROUNDING_WITH_GOOGLE_SEARCH_TOGGLE_SELECTOR = 'div[data-test-id="searchAsAToolTooltip"] mat-slide-toggle button'

--- a/models/chat.py
+++ b/models/chat.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 from pydantic import BaseModel
 from config import MODEL_NAME
 
@@ -37,3 +37,5 @@ class ChatCompletionRequest(BaseModel):
     max_output_tokens: Optional[int] = None
     stop: Optional[Union[str, List[str]]] = None
     top_p: Optional[float] = None 
+    reasoning_effort: Optional[str] = None
+    tools: Optional[List[Dict[str, Any]]] = None


### PR DESCRIPTION
支持使用open ai格式思考控制，开启内置googlesearch功能


1. 支持使用open ai格式思考控制（openai 通用格式）
 说明：
 https://ai.google.dev/gemini-api/docs/openai?hl=zh-cn#thinking
 与 Gemini API 不同，OpenAI API 提供三种思考控制级别：“低”“中”和“高”，我们会在后台将这些级别映射到 1,000、8,000 和 24,000 个思考令牌预算。
如果您想停用思考功能，可以将推理努力程度设置为“无”。

2. 支持开启内置googlesearch功能（只用了cherry studio测试）
 请求格式：
   tools： [
  {
    "type": "function",
    "function": {
      "name": "googleSearch"
    }
  }
]
![image](https://github.com/user-attachments/assets/7558e2b1-cbcf-4403-a425-fbce851c2efc)

