### PR TITLE
fix：修复window系统下只杀掉camoufox父进程，但未杀掉camoufox子进程的问题

### DIFF
--- a/launch_camoufox.py
+++ b/launch_camoufox.py
@@ -149,8 +149,8 @@ def cleanup():
                     logger.info(f"  Camoufox 进程组 (PID: {pid}) 未找到，尝试直接终止进程...")
                     camoufox_proc.terminate()
             else:
-                logger.info(f"  向 Camoufox (PID: {pid}) 发送 SIGTERM 信号...")
-                camoufox_proc.terminate()
+                subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
+                logger.info(f"已使用 taskkill 杀死了进程 {pid} 及其子进程。")
             camoufox_proc.wait(timeout=5)
             logger.info(f"  ✓ Camoufox (PID: {pid}) 已通过 SIGTERM 成功终止。")
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
之前要手动打开任务管理器杀掉进程，否则再次打开会报错
![image](https://github.com/user-attachments/assets/e00656cc-85c4-4535-8eff-b86ff74095f1)
