### PR TITLE
优化window系统下杀掉子进程功能

### DIFF
--- a/launch_camoufox.py
+++ b/launch_camoufox.py
@@ -149,8 +149,8 @@ def cleanup():
                     logger.info(f"  Camoufox 进程组 (PID: {pid}) 未找到，尝试直接终止进程...")
                     camoufox_proc.terminate()
             else:
-                logger.info(f"  向 Camoufox (PID: {pid}) 发送 SIGTERM 信号...")
-                camoufox_proc.terminate()
+                subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
+                logger.info(f"已使用 taskkill 杀死了进程 {pid} 及其子进程。")
             camoufox_proc.wait(timeout=5)
             logger.info(f"  ✓ Camoufox (PID: {pid}) 已通过 SIGTERM 成功终止。")
         except subprocess.TimeoutExpired:

--- a/launch_camoufox.py
+++ b/launch_camoufox.py
@@ -149,8 +149,12 @@ def cleanup():
                     logger.info(f"  Camoufox 进程组 (PID: {pid}) 未找到，尝试直接终止进程...")
                     camoufox_proc.terminate()
             else:
-                subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
-                logger.info(f"已使用 taskkill 杀死了进程 {pid} 及其子进程。")
+                if sys.platform == "win32":
+                    logger.info(f"进程树 (PID: {pid}) 发送终止请求")
+                    subprocess.call(['taskkill', '/T', '/PID', str(pid)])
+                else:
+                    logger.info(f"  向 Camoufox (PID: {pid}) 发送 SIGTERM 信号...")
+                    camoufox_proc.terminate()
             camoufox_proc.wait(timeout=5)
             logger.info(f"  ✓ Camoufox (PID: {pid}) 已通过 SIGTERM 成功终止。")
         except subprocess.TimeoutExpired:
@@ -164,7 +168,11 @@ def cleanup():
                     logger.info(f"  Camoufox 进程组 (PID: {pid}) 在 SIGKILL 时未找到，尝试直接强制终止...")
                     camoufox_proc.kill()
             else:
-                camoufox_proc.kill()
+                if sys.platform == "win32":
+                    logger.info(f"  强制杀死 Camoufox 进程树 (PID: {pid})")
+                    subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
+                else:
+                    camoufox_proc.kill()
             try:
                 camoufox_proc.wait(timeout=2)
                 logger.info(f"  ✓ Camoufox (PID: {pid}) 已通过 SIGKILL 成功终止。")


### PR DESCRIPTION
window系统可以用subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])强制杀掉子进程。之前powershell用CTRL C停止之后还残留了很多camoufox子进程。得用任务管理器手动杀掉
![image](https://github.com/user-attachments/assets/07de65cc-83a6-4509-b434-f65a80e4b3ad)
