### PR TITLE
feat: 优化工具面板展开逻辑，统一 Google Search 和 URL Context 行为 fix: 在多轮对话中聚合所有历史图片，解决上下文丢失问题

### DIFF
--- a/api_utils/utils.py
+++ b/api_utils/utils.py
@@ -250,7 +250,8 @@ def prepare_combined_prompt(messages: List[Message], req_id: str) -> str:
     combined_parts = []
     system_prompt_content: Optional[str] = None
     processed_system_message_indices = set()
-    
+    images_list = []  # 将 image_list 的初始化移到循环外部
+
     # 处理系统消息
     for i, msg in enumerate(messages):
         if msg.role == 'system':
@@ -284,7 +285,6 @@ def prepare_combined_prompt(messages: List[Message], req_id: str) -> str:
         role = msg.role or 'unknown'
         role_prefix_ui = f"{role_map_ui.get(role, role.capitalize())}:\n"
         current_turn_parts = [role_prefix_ui]
-        images_list = []
         
         content = msg.content or ''
         content_str = ""

--- a/browser_utils/page_controller.py
+++ b/browser_utils/page_controller.py
@@ -177,6 +177,9 @@ class PageController:
         """根据请求参数或默认配置，双向控制 Google Search 开关。"""
         self.logger.info(f"[{self.req_id}] 检查并调整 Google Search 开关...")
 
+        # 确保 "Tools" 面板已展开
+        await self._ensure_tools_panel_expanded(check_client_disconnected)
+        
         should_enable_search = self._should_enable_google_search(request_params)
 
         toggle_selector = GROUNDING_WITH_GOOGLE_SEARCH_TOGGLE_SELECTOR
@@ -209,27 +212,52 @@ class PageController:
             if isinstance(e, ClientDisconnectedError):
                  raise
 
-    async def _open_url_content(self,check_client_disconnected: Callable):
+    async def _ensure_tools_panel_expanded(self, check_client_disconnected: Callable):
+        """确保 'Tools' 面板是展开状态。"""
         try:
             collapse_tools_locator = self.page.locator('button[aria-label="Expand or collapse tools"]')
+            # 等待按钮可见，以防页面尚未完全加载
+            await expect_async(collapse_tools_locator).to_be_visible(timeout=5000)
+            
             grandparent_locator = collapse_tools_locator.locator("xpath=../..")
-
-            # 3. 获取祖父级元素的 class 属性值
-            # get_attribute 返回一个包含所有 class 的字符串，例如 "menu dropdown active"
             class_string = await grandparent_locator.get_attribute("class")
 
-            # 4. 在 Python 中进行判断
-            # 确保 class_string 不是 None，并且 'expanded' 是一个独立的 class
             if class_string and "expanded" not in class_string.split():
+                self.logger.info(f"[{self.req_id}] 'Tools' 面板是折叠的，正在点击展开...")
                 await collapse_tools_locator.click(timeout=CLICK_TIMEOUT_MS)
-                await asyncio.sleep(0.5)
+                await asyncio.sleep(0.5) # 等待动画完成
+                await self._check_disconnect(check_client_disconnected, "展开 'Tools' 面板后")
+                self.logger.info(f"[{self.req_id}] ✅ 'Tools' 面板已展开。")
+            else:
+                self.logger.info(f"[{self.req_id}] 'Tools' 面板已处于展开状态。")
+        except Exception as e:
+            self.logger.error(f"[{self.req_id}] ❌ 检查或展开 'Tools' 面板时出错: {e}")
+            # 如果是客户端断开连接，则重新抛出
+            if isinstance(e, ClientDisconnectedError):
+                raise
+            # 对于其他错误，记录并继续，但后续操作可能会失败
+            await save_error_snapshot(f"expand_tools_panel_error_{self.req_id}")
+
+
+    async def _open_url_content(self,check_client_disconnected: Callable):
+        try:
+            await self._ensure_tools_panel_expanded(check_client_disconnected)
+            
             use_url_content_selector = self.page.locator(USE_URL_CONTEXT_SELECTOR)
+            await expect_async(use_url_content_selector).to_be_visible(timeout=5000)
             is_checked = await use_url_content_selector.get_attribute("aria-checked")
+            
             if "false" == is_checked:
+                self.logger.info(f"[{self.req_id}] URL Context 未选中，正在点击以启用...")
                 await use_url_content_selector.click(timeout=CLICK_TIMEOUT_MS)
                 await self._check_disconnect(check_client_disconnected, "点击URLCONTEXT")
+                self.logger.info(f"[{self.req_id}] ✅ URL Context 已启用。")
+            else:
+                self.logger.info(f"[{self.req_id}] URL Context 已处于启用状态。")
         except Exception as e:
             self.logger.error(f"[{self.req_id}] ❌ 操作USE_URL_CONTEXT_SELECTOR时发生错误:{e}。")
+            if isinstance(e, ClientDisconnectedError):
+                raise
 
     async def _control_thinking_budget_toggle(self, should_be_checked: bool, check_client_disconnected: Callable):
         """


### PR DESCRIPTION
## 🧐 PR 类型
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🚀 Chore
## 📝 描述
本次更新主要优化了工具（Tools）面板的展开逻辑，解决了 `Google Search` 开关与 `Url Context` 开关交互行为不一致的问题。
在之前的版本中：
- 当用户启用 `Url Context` 时，系统会先自动展开 `Tools` 面板，然后再操作开关，交互流畅。
- 然而，当用户启用 `Google Search` 时，`Tools` 面板并不会自动展开。这导致系统在前端找不到对应的 `Google Search` 按钮元素，必须等待操作超时后才能响应用户请求。
这种不一致的设计极大地延长了用户的等待时间，造成了糟糕的用户体验。
## 👨‍💻 实现更改
- **统一交互逻辑**：调整了 `Google Search` 开关的触发流程，现在在执行切换操作前，会先检查并确保其父级 `Tools` 面板处于展开状态。
- **提升响应速度**：通过确保 `Tools` 面板已展开，系统可以立即定位并操作 `Google Search` 开关，从而消除了不必要的超时等待。
最终效果是，`Google Search` 的交互行为现在与 `Url Context` 完全一致，响应迅速，提升了整体可用性。
## ✅ 如何测试
1.  确保 `Tools` 面板当前处于 **折叠** 状态。
2.  发起请求
3.  **预期结果**：`Tools` 面板应立即展开，并且 `Google Search` 开关成功切换到正确的状态，整个过程无明显延迟。