### PR TITLE
feat: 默认禁用URL上下文并更新注入模型

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,7 @@ DEFAULT_TOP_P=0.95
 DEFAULT_STOP_SEQUENCES=["用户:"]
 
 # 是否在处理请求时自动打开并使用 "URL Context" 功能,此工具功能详情可参考:https://ai.google.dev/gemini-api/docs/url-context
-ENABLE_URL_CONTEXT=true
+ENABLE_URL_CONTEXT=false
 
 # 是否默认启用 "指定思考预算" 功能 (true/false),不启用时模型一般将自行决定思考预算
 # 当 API 请求中未提供 reasoning_effort 参数时将使用此值。

--- a/browser_utils/more_modles.js
+++ b/browser_utils/more_modles.js
@@ -23,44 +23,18 @@
     // 模型配置列表
     // 已按要求将 jfdksal98a 放到 blacktooth 的下面
     const MODELS_TO_INJECT = [
-        // Blacktooth 模型 (原 Toothless)
-        {
-            name: 'models/blacktooth-ab-test', // 已改为 blacktooth-ab-test
-            displayName: `🏴‍☠️ Blacktooth (脚本 ${SCRIPT_VERSION})`, // emoji 改为 🏴‍☠️，名称改为 Blacktooth
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        },
-        // --- jfdksal98a 模型已移动到此处 ---
-        {
-            name: 'models/jfdksal98a',
-            displayName: `🪐 jfdksal98a (脚本 ${SCRIPT_VERSION})`,
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        },
-        // --- 其他模型 ---
-        {
-            name: 'models/gemini-2.5-pro-preview-03-25',
-            displayName: `✨ Gemini 2.5 Pro 03-25 (脚本 ${SCRIPT_VERSION})`,
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        },
-        {
-            name: 'models/goldmane-ab-test',
-            displayName: `🦁 Goldmane (脚本 ${SCRIPT_VERSION})`,
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        },
-        {
-            name: 'models/claybrook-ab-test',
-            displayName: `💧 Claybrook (脚本 ${SCRIPT_VERSION})`,
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        },
-        {
-            name: 'models/frostwind-ab-test',
-            displayName: `❄️ Frostwind (脚本 ${SCRIPT_VERSION})`,
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        },
-        {
-            name: 'models/calmriver-ab-test',
-            displayName: `🌊 Calmriver (脚本 ${SCRIPT_VERSION})`,
-            description: `由脚本 ${SCRIPT_VERSION} 注入的模型`
-        }
+        { name: 'models/gemini-2.5-pro-preview-03-25', displayName: `✨ Gemini 2.5 Pro 03-25 (Script ${SCRIPT_VERSION})`, description: `Model injected by script ${SCRIPT_VERSION}` },
+        { name: 'models/gemini-2.5-pro-exp-03-25', displayName: `✨ Gemini 2.5 Pro 03-25 (Script ${SCRIPT_VERSION})`, description: `Model injected by script ${SCRIPT_VERSION}` },
+        { name: 'models/gemini-2.5-pro-preview-06-05', displayName: `✨ Gemini 2.5 Pro 03-25 (Script ${SCRIPT_VERSION})`, description: `Model injected by script ${SCRIPT_VERSION}` },
+
+        //下面模型已经失效，留下来怀念
+        // { name: 'models/blacktooth-ab-test', displayName: `🏴‍☠️ Blacktooth (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` },
+        // { name: 'models/jfdksal98a', displayName: `🪐 jfdksal98a (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` },
+        // { name: 'models/gemini-2.5-pro-preview-03-25', displayName: `✨ Gemini 2.5 Pro 03-25 (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` },
+        // { name: 'models/goldmane-ab-test', displayName: `🦁 Goldmane (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` },
+        // { name: 'models/claybrook-ab-test', displayName: `💧 Claybrook (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` },
+        // { name: 'models/frostwind-ab-test', displayName: `❄️ Frostwind (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` },
+        // { name: 'models/calmriver-ab-test', displayName: `🌊 Calmriver (脚本 ${SCRIPT_VERSION})`, description: `由脚本 ${SCRIPT_VERSION} 注入的模型` }
     ];
 
     // JSON 结构中的字段索引

--- a/config/constants.py
+++ b/config/constants.py
@@ -20,7 +20,7 @@ DEFAULT_TEMPERATURE = float(os.environ.get('DEFAULT_TEMPERATURE', '1.0'))
 DEFAULT_MAX_OUTPUT_TOKENS = int(os.environ.get('DEFAULT_MAX_OUTPUT_TOKENS', '65536'))
 DEFAULT_TOP_P = float(os.environ.get('DEFAULT_TOP_P', '0.95'))
 # --- 默认功能开关 ---
-ENABLE_URL_CONTEXT = os.environ.get('ENABLE_URL_CONTEXT', 'true').lower() in ('true', '1', 'yes')
+ENABLE_URL_CONTEXT = os.environ.get('ENABLE_URL_CONTEXT', 'false').lower() in ('true', '1', 'yes')
 ENABLE_THINKING_BUDGET = os.environ.get('ENABLE_THINKING_BUDGET', 'false').lower() in ('true', '1', 'yes')
 DEFAULT_THINKING_BUDGET = int(os.environ.get('DEFAULT_THINKING_BUDGET', '8192'))
 ENABLE_GOOGLE_SEARCH = os.environ.get('ENABLE_GOOGLE_SEARCH', 'false').lower() in ('true', '1', 'yes')


### PR DESCRIPTION
- **默认禁用URL上下文**:
    - 将 `ENABLE_URL_CONTEXT` 的默认值从 `true` 修改为 `false`，以提升开箱即用的安全性。
    - 用户现在可以通过在 `.env` 文件中设置 `ENABLE_URL_CONTEXT=true` 来显式启用该功能。
    - 同步更新了 `.env.example` 以反映此项变更。

- **更新注入模型**:
    - 修改了 `browser_utils/more_modles.js` 脚本。
    - 新增了以下模型：
        - `gemini-2.5-pro-preview-03-25`
        - `gemini-2.5-pro-exp-03-25` - `gemini-2.5-pro-preview-06-05`
    - 将所有模型定义都压缩为单行，并注释掉了已失效的旧模型，以提高代码的可读性和整洁度。
    
    #205 #206 