### PR TITLE
修复05年7月25日aitudio前端更新导致的程序崩

### DIFF
--- a/browser_utils/initialization.py
+++ b/browser_utils/initialization.py
@@ -416,7 +416,7 @@ async def _initialize_page_logic(browser: AsyncBrowser):
             await expect_async(found_page.locator(INPUT_SELECTOR)).to_be_visible(timeout=10000)
             logger.info("-> ✅ 核心输入区域可见。")
             
-            model_name_locator = found_page.locator('mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium')
+            model_name_locator = found_page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
             try:
                 model_name_on_page = await model_name_locator.first.inner_text(timeout=5000)
                 logger.info(f"-> 🤖 页面检测到的当前模型: {model_name_on_page}")

--- a/browser_utils/model_management.py
+++ b/browser_utils/model_management.py
@@ -280,7 +280,7 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
                 page_display_match = True
             else:
                 try:
-                    model_name_locator = page.locator('mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium')
+                    model_name_locator = page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
                     actual_displayed_model_name_on_page_raw = await model_name_locator.first.inner_text(timeout=5000)
                     actual_displayed_model_name_on_page = actual_displayed_model_name_on_page_raw.strip()
                     normalized_actual_display = actual_displayed_model_name_on_page.lower()
@@ -306,7 +306,7 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
         current_displayed_name_for_revert_stripped = "无法读取"
         
         try:
-            model_name_locator_revert = page.locator('mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium')
+            model_name_locator_revert = page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
             current_displayed_name_for_revert_raw = await model_name_locator_revert.first.inner_text(timeout=5000)
             current_displayed_name_for_revert_stripped = current_displayed_name_for_revert_raw.strip()
             logger.info(f"[{req_id}] 恢复：页面当前显示的模型名称 (原始: '{current_displayed_name_for_revert_raw}', 清理后: '{current_displayed_name_for_revert_stripped}')")
@@ -529,7 +529,7 @@ async def _set_model_from_page_display(page: AsyncPage, set_storage: bool = Fals
     
     try:
         logger.info("   尝试从页面显示元素读取当前模型名称...")
-        model_name_locator = page.locator('mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium')
+        model_name_locator = page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
         displayed_model_name_from_page_raw = await model_name_locator.first.inner_text(timeout=7000)
         displayed_model_name = displayed_model_name_from_page_raw.strip()
         logger.info(f"   页面当前显示模型名称 (原始: '{displayed_model_name_from_page_raw}', 清理后: '{displayed_model_name}')")


### PR DESCRIPTION
描述：
本次 PR 修复了三个与 model_name_locator 相关的选择器问题，提升了代码的健壮性和可靠性。

修复内容：
1. 修改 browser_utils/initialization.py 文件：
    * 定位代码： 找到定义 model_name_locator 变量的代码行（约在第 419 行）。
    * 修改前：
    * model_name_locator = page.locator('mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium')
    * 
    * 修改后：
    * model_name_locator = page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
    * 
2. 修改 browser_utils/model_management.py 文件（局部更新）：
    * 定位代码： 找到 _set_model_from_page_display 函数（约在第 530 行）。
    * 修改前：
    * model_name_locator = page.locator('mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium')
    * 
    * 修改后：
    * model_name_locator = page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
    * 
3. 修改 browser_utils/model_management.py 文件（全局替换）：
    * 操作： 搜索所有以下字符串：
    * 'mat-select[data-test-ms-model-selector] div.model-option-content span.gmat-body-medium'
    * 替换为：
    * 'mat-select[data-test-ms-model-selector] .model-option-content span'