### PR TITLE
修复“清空聊天”功能失败

### DIFF
--- a/config/selectors.py
+++ b/config/selectors.py
@@ -11,7 +11,7 @@ INPUT_SELECTOR2 = PROMPT_TEXTAREA_SELECTOR
 # --- 按钮选择器 ---
 SUBMIT_BUTTON_SELECTOR = 'button[aria-label="Run"].run-button'
 CLEAR_CHAT_BUTTON_SELECTOR = 'button[data-test-clear="outside"][aria-label="Clear chat"]'
-CLEAR_CHAT_CONFIRM_BUTTON_SELECTOR = 'button.mdc-button:has-text("Continue")'
+CLEAR_CHAT_CONFIRM_BUTTON_SELECTOR = 'button.primary:has-text("Continue")'
 UPLOAD_BUTTON_SELECTOR = 'button[aria-label="Upload File"]'
 
 # --- 响应相关选择器 ---
@@ -20,7 +20,7 @@ RESPONSE_TEXT_SELECTOR = 'ms-cmark-node.cmark-node'
 
 # --- 加载和状态选择器 ---
 LOADING_SPINNER_SELECTOR = 'button[aria-label="Run"].run-button svg .stoppable-spinner'
-OVERLAY_SELECTOR = 'div.cdk-overlay-backdrop'
+OVERLAY_SELECTOR = '.mat-mdc-dialog-inner-container'
 
 # --- 错误提示选择器 ---
 ERROR_TOAST_SELECTOR = 'div.toast.warning, div.toast.error'


### PR DESCRIPTION
问题描述 (Problem)
在处理完一个请求后，自动化的“清空聊天”功能失败。具体表现为，当点击“清空聊天”按钮后弹出的确认对话框中，程序无法点击“继续”按钮，导致后续所有请求被阻塞。

根本原因 (Root Cause)
该问题由 Google AI Studio 前端界面的更新导致，原始的 CSS 选择器已经失效。我们最初的修复尝试也不够精确，导致了后续的错误。

原始选择器失效: 项目中最初用于定位“继续”按钮的选择器 button.mdc-button:has-text("Continue") 已经过时。
中间修复不精确: 我们在修复过程中，尝试使用 [ms-button].primary 作为新的选择器。但根据错误日志，这个选择器不够精确，它匹配到了页面上的多个元素（包括“Get API key”按钮），违反了 Playwright 的严格模式，该模式要求选择器必须指向唯一元素。
对话框容器变更: 旧的对话框遮罩层选择器 div.cdk-overlay-backdrop 也不再准确，新的对话框使用了不同的容器类。
解决方案 (Solution)
为了解决这个问题，我们对 config/selectors.py 文件进行了精确的更新：

更新确认按钮选择器:

文件: [config/selectors.py:14](vscode-webview://0pe505edp4itsls2e8cpkeqa2osmscv8l0adtf4vhcl604urstto/config/selectors.py:14)
最终选择器: button.primary:has-text("Continue")
说明: 这个最终的选择器通过组合类名 .primary 和伪类 :has-text("Continue")，确保了只精确匹配文本内容为 "Continue" 的主操作按钮，从而解决了选择器不唯一的问题。
更新对话框容器选择器:

文件: [config/selectors.py:24](vscode-webview://0pe505edp4itsls2e8cpkeqa2osmscv8l0adtf4vhcl604urstto/config/selectors.py:24)
旧选择器: div.cdk-overlay-backdrop
新选择器: .mat-mdc-dialog-inner-container
说明: 更新为新的对话框内部容器选择器，使程序能够更稳定地等待对话框出现。
通过以上修改，自动化脚本现在可以准确地定位并点击确认按钮，恢复了“清空聊天”功能的正常运作。