### PR TITLE
“8月29日修复切换模型的ui更新和清空对话按钮移除后导致的崩溃和选择器失效”

### DIFF
--- a/browser_utils/initialization.py
+++ b/browser_utils/initialization.py
@@ -416,13 +416,36 @@ async def _initialize_page_logic(browser: AsyncBrowser):
             await expect_async(found_page.locator(INPUT_SELECTOR)).to_be_visible(timeout=10000)
             logger.info("-> ✅ 核心输入区域可见。")
             
-            model_name_locator = found_page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
-            try:
-                model_name_on_page = await model_name_locator.first.inner_text(timeout=5000)
-                logger.info(f"-> 🤖 页面检测到的当前模型: {model_name_on_page}")
-            except PlaywrightAsyncError as e:
-                logger.error(f"获取模型名称时出错 (model_name_locator): {e}")
-                raise
+            # 改进模型名称获取，使用新的选择器
+            model_name_on_page = None
+            model_selectors = [
+                # 新的 ms-model-selector-v3 结构选择器
+                'ms-model-selector-v3 button.model-selector-card .title',
+                'ms-model-selector-v3 .model-selector-card .title',
+                'ms-model-selector-v3 .title',
+                'ms-model-selector-v3 .subtitle[data-test-id="model-name"]',
+                'ms-model-selector-v3 .subtitle',
+                # 旧的 mat-select 结构选择器（作为备用）
+                'mat-select[data-test-ms-model-selector] .model-option-content span',
+                'mat-select[data-test-ms-model-selector] span',
+                'mat-select .model-option-content span',
+                'mat-select span'
+            ]
+            
+            for selector in model_selectors:
+                try:
+                    logger.info(f"   尝试模型选择器: {selector}")
+                    model_name_locator = found_page.locator(selector)
+                    model_name_on_page = await model_name_locator.first.inner_text(timeout=5000)
+                    if model_name_on_page and model_name_on_page.strip():
+                        logger.info(f"-> 🤖 页面检测到的当前模型: {model_name_on_page}")
+                        break
+                except Exception as e:
+                    logger.debug(f"   选择器 {selector} 失败: {e}")
+                    continue
+            
+            if not model_name_on_page:
+                logger.warning("-> ⚠️ 无法获取模型名称，但继续初始化")
             
             result_page_instance = found_page
             result_page_ready = True

--- a/config/selectors.py
+++ b/config/selectors.py
@@ -10,6 +10,7 @@ INPUT_SELECTOR2 = PROMPT_TEXTAREA_SELECTOR
 
 # --- 按钮选择器 ---
 SUBMIT_BUTTON_SELECTOR = 'button[aria-label="Run"].run-button'
+NEW_CHAT_LINK_SELECTOR = 'a[href="/prompts/new_chat"]'
 CLEAR_CHAT_BUTTON_SELECTOR = 'button[data-test-clear="outside"][aria-label="Clear chat"]'
 CLEAR_CHAT_CONFIRM_BUTTON_SELECTOR = 'button.ms-button-primary:has-text("Continue")'
 UPLOAD_BUTTON_SELECTOR = 'button[aria-label="Upload File"]'


### PR DESCRIPTION
# 一、模型切换部分重构
描述:

本次提交对 browser_utils 模块中的 initialization.py 和 model_management.py 进行了统一的重构。核心目标是提高在AI Studio页面上识别和读取当前所选模型名称的可靠性。此更新通过引入多种备用选择器来确保程序的向后兼容性和稳定性，以应对前端UI的潜在变化。

## 文件一: browser_utils/initialization.py
函数: _initialize_page_logic()
[原第 419-425 行] 原代码使用单一、固定的 Playwright 选择器 mat-select[data-test-ms-model-selector] .model-option-content span 来尝试获取页面上显示的当前模型名称。

### 原代码
model_name_locator = found_page.locator('mat-select[data-test-ms-model-selector] .model-option-content span')
try:
    model_name_on_page = await model_name_locator.first.inner_text(timeout=5000)
    logger.info(f"-> 🤖 页面检测到的当前模型: {model_name_on_page}")
except PlaywrightAsyncError as e:
    logger.error(f"获取模型名称时出错 (model_name_locator): {e}")
    raise

python


[新第 425-449 行] 已修改为：引入一个包含多个备选选择器的列表 (model_selectors)。程序现在会遍历此列表，按顺序尝试每一个选择器来定位模型名称。这增强了在不同前端UI版本下的兼容性。

### 新代码
model_name_on_page = None
model_selectors = [
    # 新的 ms-model-selector-v3 结构选择器
    'ms-model-selector-v3 button.model-selector-card .title',
    # ... 其他备选选择器 ...
    # 旧的 mat-select 结构选择器（作为备用）
    'mat-select[data-test-ms-model-selector] .model-option-content span',
]

for selector in model_selectors:
    try:
        # ... 尝试获取元素 ...
        if model_name_on_page and model_name_on_page.strip():
            # ... 成功后跳出循环 ...
            break
    except Exception as e:
        # ... 失败则继续尝试下一个 ...
        continue

python


## 文件二: browser_utils/model_management.py
函数: switch_ai_studio_model()
[原第 282-285 行] 在验证模型切换是否成功时，使用单一选择器 mat-select[...] 来读取页面显示的模型名称。

[新第 282-300 行] 已修改为：使用与 initialization.py 中相同的选择器列表和循环尝试逻辑，以更可靠地获取页面上当前的模型名称进行验证。

[原第 308-311 行] 在模型切换失败后的恢复逻辑中，再次使用单一选择器 mat-select[...] 尝试读取当前模型以进行状态恢复。

[新第 308-333 行] 已修改为：同样地，此处也替换为选择器列表和循环尝试逻辑，以确保在恢复状态时能稳定地读取到UI上的模型名称。

函数: _set_model_from_page_display()
[原第 531-535 行] 在从页面显示来同步全局模型状态时，使用单一选择器 mat-select[...] 获取模型名称。

[新第 531-560 行] 已修改为：替换为选择器列表和循环尝试逻辑。这是本次重构的核心，确保了所有从UI读取模型名称的入口点都使用了同样健壮的方法。

---

#  二、清空对话按钮步骤改为新建对话
Google AI Studio 的前端界面进行了更新，导致原有的“清空对话” (Clear chat) 按钮被移除。本代理项目中，clear_chat_history 函数依赖此按钮来重置对话上下文。

由于该按钮的缺失，该函数已失效，导致代理在处理连续请求时无法清空历史记录，对话内容会不断累积，最终可能超出模型的上下文长度限制，引发错误。

## 解决方案 (Solution)
为了解决此问题并恢复清空上下文的功能，我们采用了新的策略来替代旧的逻辑：

定位新元素：经分析，界面上新增了一个功能等价的“新建对话” (New chat) 链接，其 HTML 结构为 <a href="/prompts/new_chat">。
更新实现方式：我们决定放弃旧的“点击清空 -> 点击确认”的两步操作，转而采用更稳定、更接近用户行为的 “模拟点击‘新建对话’链接” 的单步操作。
优点：这种方法不仅恢复了核心功能，而且通过定位 href 属性，比依赖随时可能变化的 class 或 aria-label 更加健壮和面向未来。
具体改动 (Changes)
config/selectors.py

新增 了一个 CSS 选择器 NEW_CHAT_LINK_SELECTOR = 'a[href="/prompts/new_chat"]'，用于精确、稳定地定位“新建对话”链接。
browser_utils/page_controller.py

更新了导入：移除了已废弃的 CLEAR_CHAT_BUTTON_SELECTOR 和 CLEAR_CHAT_CONFIRM_BUTTON_SELECTOR，并导入了新的 NEW_CHAT_LINK_SELECTOR。
重写了 clear_chat_history 函数：
完全替换了旧的、复杂的函数实现。
新逻辑现在会查找并点击“新建对话”链接。
增加了操作日志，并会在点击后验证页面的 URL 是否成功跳转到 new_chat 页面，以确保操作的可靠性。
保留了完整的异常捕获和错误快照功能。