### PR TITLE
添加了对Camoufox和Playwright之间传递代理参数问题的描述和修复指南/Document Camoufox proxy error and fix

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,6 +113,43 @@ source venv/bin/activate  # Linux/macOS
 
 - 或修改 [`launch_camoufox.py`](../launch_camoufox.py) 的 `--server-port` 参数。
 
+### Camoufox 启动时 proxy 错误
+
+**问题现象**: 未配置代理环境变量时，Camoufox 启动失败：
+
+```
+Error: proxy: expected object, got null
+```
+
+**原因**: Camoufox 0.4.11 的 utils.py 会无条件传递 proxy 参数给 Playwright，即使值为 None。
+
+**修复方法**: 修改 Camoufox 源码文件：
+
+```
+/usr/local/lib/python3.10/site-packages/camoufox/utils.py
+```
+
+在 `launch_options` 函数中，将：
+
+```python
+return {
+    ...
+    "proxy": proxy,
+    ...
+}
+```
+
+改为：
+
+```python
+result = {
+    ...  # 删除 "proxy": proxy,其他配置保持不变
+}
+if proxy is not None:
+    result["proxy"] = proxy
+return result
+```
+
 ## 认证相关问题
 
 ### 认证失败 (特别是无头模式)


### PR DESCRIPTION
在Docker 环境中部署了一次，在没有配置代理时，Camoufox 启动失败：
Error: proxy: expected object, got null

看了一下Camoufox的仓库，有一个PR提到了这个问题daijro/camoufox#361，简单来说就是Camoufox 0.4.11 的 utils.py 会无条件将 proxy 参数传递给 Playwright，即使 proxy=None 也会序列化为 JSON 的 null 值，但是Playwright中不配置代理的要求是不传递这个参数，Camoufox却传递了null，于是导致 Playwright 报错。

三月份之后Camoufox仓库的main分支就再也没更新过了，所以一直没有merge进去。于是我在docs/troubleshooting.md里面加了一段如何修复这个问题的描述，如果用户不需要代理，可以按照这个思路去给Camoufox的代码打补丁。