### PR TITLE
关闭预算开关前检查模型

### DIFF
--- a/browser_utils/page_controller.py
+++ b/browser_utils/page_controller.py
@@ -170,6 +170,9 @@ class PageController:
             self.logger.info(f"[{self.req_id}] 该模型无主思考开关，跳过开关设置。")
 
         if not desired_enabled:
+            # 跳过无预算开关的模型
+            if self._uses_thinking_level(model_id_to_use):
+                 return
             # 若关闭思考，则确保预算开关关闭（兼容旧UI）
             await self._control_thinking_budget_toggle(
                 should_be_checked=False,


### PR DESCRIPTION
未传入思考模式指令（None）或者传了关闭，会对无思考预算开关的模型执行关闭操作，进而报错。在关闭前检查是否为无预算开关的模型，如果是则跳过