### PR TITLE
Fix temporary chat selector

### DIFF
--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -567,7 +567,8 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
     """
     try:
         incognito_button_locator = page.locator(
-            'button[aria-label="Temporary chat toggle"]'
+            'button[aria-label="Temporary chat toggle"]',
+            'button[aria-label="Toggle temporary chat"]'
         )
 
         await incognito_button_locator.wait_for(state="visible", timeout=10000)

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -161,7 +161,8 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
                 try:
                     logger.debug("[Model] Re-enabling temporary chat mode...")
                     incognito_button_locator = page.locator(
-                        'button[aria-label="Temporary chat toggle"]'
+                        'button[aria-label="Temporary chat toggle"]',
+                        'button[aria-label="Toggle temporary chat"]'
                     )
 
                     await incognito_button_locator.wait_for(


### PR DESCRIPTION
```
16:51:40.859 WRN SYS 13shv1v [UI] Error in temporary chat mode: Locator.wait_for: Timeout 10000ms exceeded.
Call log:
- waiting for locator("button[aria-label=\"Temporary chat toggle\"]") to be visible
```
<img width="367" height="256" alt="image" src="https://github.com/user-attachments/assets/badeb1da-4bf6-4537-86a9-f2536f319b15" />

google正在灰度这个标签名
