### PR TITLE
Fix temporary chat selector

### DIFF
--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -570,7 +570,6 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
             'button[aria-label="Temporary chat toggle"]', 'button[aria-label="Toggle temporary chat"]'
         )
 
-        
         await incognito_button_locator.wait_for(state="visible", timeout=10000)
 
         button_classes = await incognito_button_locator.get_attribute("class")

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -567,7 +567,8 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
     """
     try:
         incognito_button_locator = page.locator(
-            'button[aria-label="Temporary chat toggle"]'
+            'button[aria-label="Temporary chat toggle"]',
+            'button[aria-label="Toggle temporary chat"]'
         )
 
         await incognito_button_locator.wait_for(state="visible", timeout=10000)

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -567,10 +567,10 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
     """
     try:
         incognito_button_locator = page.locator(
-            'button[aria-label="Temporary chat toggle"]',
-            'button[aria-label="Toggle temporary chat"]'
+            'button[aria-label="Temporary chat toggle"]', 'button[aria-label="Toggle temporary chat"]'
         )
 
+        
         await incognito_button_locator.wait_for(state="visible", timeout=10000)
 
         button_classes = await incognito_button_locator.get_attribute("class")

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -567,7 +567,7 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
     """
     incognito_selector = 'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
     menu_trigger_selector = 'button[aria-label="View more actions"]'
-    
+
     incognito_locator = page.locator(incognito_selector)
     menu_trigger = page.locator(menu_trigger_selector)
 

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -560,12 +560,85 @@ async def signal_camoufox_shutdown() -> None:  # pragma: no cover
         )
 
 
-async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cover
+async def _is_temporary_chat_active(page: AsyncPage) -> bool:
+    """Best-effort check for whether Temporary chat is currently enabled.
+
+    Supports both the legacy toggle-class signal and the newer UI variants:
+    - menu item checkmark (`data-test-incognito-checkmark`)
+    - header indicator (`ms-incognito-mode-indicator`)
+    """
+
+    try:
+        # Newer UI: header indicator appears only when Temporary chat is active.
+        indicator_locator = page.locator(
+            "ms-incognito-mode-indicator [data-test-id='main-text'], "
+            "ms-incognito-mode-indicator .main-text"
+        )
+        indicator_count = await indicator_locator.count()
+        for i in range(indicator_count):
+            try:
+                indicator_item = indicator_locator.nth(i)
+                if not await indicator_item.is_visible(timeout=500):
+                    continue
+                indicator_text = (await indicator_item.inner_text()).strip().lower()
+                if indicator_text == "temporary chat":
+                    return True
+            except Exception:
+                continue
+
+        # Menu button variants (legacy and gray-release UI).
+        toggle_locator = page.locator(
+            "button[data-test-incognito-toggle], "
+            'button[aria-label="Temporary chat toggle"], '
+            'button[aria-label="Toggle temporary chat"]'
+        )
+        if await toggle_locator.count() > 0:
+            toggle_button = toggle_locator.first
+
+            # New UI: active state is represented by a checkmark inside the menu item.
+            try:
+                checkmark_locator = toggle_button.locator(
+                    "[data-test-incognito-checkmark]"
+                )
+                if (
+                    await checkmark_locator.count() > 0
+                    and await checkmark_locator.first.is_visible(timeout=500)
+                ):
+                    return True
+            except Exception:
+                pass
+
+            # Legacy/alternative signals.
+            for attr_name in ("aria-pressed", "aria-checked"):
+                try:
+                    attr_value = await toggle_button.get_attribute(attr_name)
+                    if attr_value and attr_value.lower() == "true":
+                        return True
+                except Exception:
+                    pass
+
+            try:
+                button_classes = await toggle_button.get_attribute("class") or ""
+                if "ms-button-active" in button_classes:
+                    return True
+            except Exception:
+                pass
+
+        return False
+    except Exception:
+        return False
+
+
+async def enable_temporary_chat_mode(page: AsyncPage) -> bool:  # pragma: no cover
     """
     Check and enable "Temporary chat" mode in the AI Studio interface.
     Supports both direct UI visibility and collapsed menu visibility.
     """
-    incognito_selector = 'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
+    incognito_selector = (
+        "button[data-test-incognito-toggle], "
+        'button[aria-label="Temporary chat toggle"], '
+        'button[aria-label="Toggle temporary chat"]'
+    )
     menu_trigger_selector = 'button[aria-label="View more actions"]'
 
     incognito_locator = page.locator(incognito_selector)
@@ -585,23 +658,23 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
                 await incognito_locator.wait_for(state="visible", timeout=5000)
             else:
                 logger.warning("[UI] Neither button nor menu trigger found")
-                return
+                return False
 
-        # Status Check
-        button_classes = await incognito_locator.get_attribute("class") or ""
-
-        if "ms-button-active" in button_classes:
+        if await _is_temporary_chat_active(page):
             logger.debug("[UI] Temporary chat mode already active")
         else:
             logger.debug("[UI] Enabling temporary chat mode")
             await incognito_locator.click(timeout=5000, force=True)
             await asyncio.sleep(1)
 
+        enabled = await _is_temporary_chat_active(page)
+
         # Recovery: Close menu if still expanded
         # Checking aria-expanded is more precise than a boolean flag
         if await menu_trigger.get_attribute("aria-expanded") == "true":
             logger.debug("[UI] Closing menu to restore UI state")
             await page.keyboard.press("Escape")
+        return enabled
 
     except asyncio.CancelledError:
         raise
@@ -610,3 +683,4 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
         # Final safety attempt to clear any stuck UI
         if await menu_trigger.get_attribute("aria-expanded") == "true":
             await page.keyboard.press("Escape")
+        return await _is_temporary_chat_active(page)

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -567,7 +567,7 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cov
     """
     try:
         incognito_button_locator = page.locator(
-            'button[aria-label="Temporary chat toggle"]', 'button[aria-label="Toggle temporary chat"]'
+            'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
         )
 
         await incognito_button_locator.wait_for(state="visible", timeout=10000)

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -593,16 +593,15 @@ async def _is_temporary_chat_active(page: AsyncPage) -> bool:
             'button[aria-label="Toggle temporary chat"]'
         )
         if await toggle_locator.count() > 0:
-            toggle_button = toggle_locator.first
-
             # New UI: active state is represented by a checkmark inside the menu item.
             try:
-                checkmark_locator = toggle_button.locator(
-                    "[data-test-incognito-checkmark]"
+                checkmark_locator = page.locator(
+                    "button[data-test-incognito-toggle] [data-test-incognito-checkmark], "
+                    'button[aria-label="Temporary chat toggle"] [data-test-incognito-checkmark], '
+                    'button[aria-label="Toggle temporary chat"] [data-test-incognito-checkmark]'
                 )
                 if (
                     await checkmark_locator.count() > 0
-                    and await checkmark_locator.first.is_visible(timeout=500)
                 ):
                     return True
             except Exception:
@@ -611,14 +610,14 @@ async def _is_temporary_chat_active(page: AsyncPage) -> bool:
             # Legacy/alternative signals.
             for attr_name in ("aria-pressed", "aria-checked"):
                 try:
-                    attr_value = await toggle_button.get_attribute(attr_name)
+                    attr_value = await toggle_locator.get_attribute(attr_name)
                     if attr_value and attr_value.lower() == "true":
                         return True
                 except Exception:
                     pass
 
             try:
-                button_classes = await toggle_button.get_attribute("class") or ""
+                button_classes = await toggle_locator.get_attribute("class") or ""
                 if "ms-button-active" in button_classes:
                     return True
             except Exception:
@@ -643,6 +642,18 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> bool:  # pragma: no cov
 
     incognito_locator = page.locator(incognito_selector)
     menu_trigger = page.locator(menu_trigger_selector)
+
+    async def _close_menu_if_needed() -> None:
+        """Best-effort menu cleanup that tolerates UI variants without a menu trigger."""
+        try:
+            if await menu_trigger.count() == 0:
+                return
+            if await menu_trigger.is_visible():
+                if await menu_trigger.get_attribute("aria-expanded") == "true":
+                    logger.debug("[UI] Closing menu to restore UI state")
+                    await page.keyboard.press("Escape")
+        except Exception:
+            pass
 
     try:
         # Fast path
@@ -670,10 +681,7 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> bool:  # pragma: no cov
         enabled = await _is_temporary_chat_active(page)
 
         # Recovery: Close menu if still expanded
-        # Checking aria-expanded is more precise than a boolean flag
-        if await menu_trigger.get_attribute("aria-expanded") == "true":
-            logger.debug("[UI] Closing menu to restore UI state")
-            await page.keyboard.press("Escape")
+        await _close_menu_if_needed()
         return enabled
 
     except asyncio.CancelledError:
@@ -681,6 +689,5 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> bool:  # pragma: no cov
     except Exception as e:
         logger.warning(f"[UI] Error in temporary chat mode: {e}")
         # Final safety attempt to clear any stuck UI
-        if await menu_trigger.get_attribute("aria-expanded") == "true":
-            await page.keyboard.press("Escape")
+        await _close_menu_if_needed()
         return await _is_temporary_chat_active(page)

--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -563,30 +563,50 @@ async def signal_camoufox_shutdown() -> None:  # pragma: no cover
 async def enable_temporary_chat_mode(page: AsyncPage) -> None:  # pragma: no cover
     """
     Check and enable "Temporary chat" mode in the AI Studio interface.
-    This is an independent UI operation and should be called after the page is fully stable.
+    Supports both direct UI visibility and collapsed menu visibility.
     """
+    incognito_selector = 'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
+    menu_trigger_selector = 'button[aria-label="View more actions"]'
+    
+    incognito_locator = page.locator(incognito_selector)
+    menu_trigger = page.locator(menu_trigger_selector)
+
     try:
-        incognito_button_locator = page.locator(
-            'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
-        )
+        # Fast path
+        logger.debug("[UI] Searching for temporary chat button (Fast path)")
+        try:
+            await incognito_locator.wait_for(state="visible", timeout=3000)
+        except Exception:
+            # Fallback
+            logger.debug("[UI] Button not visible, attempting to open menu")
+            if await menu_trigger.is_visible():
+                await menu_trigger.click()
+                # Wait for the menu item to appear
+                await incognito_locator.wait_for(state="visible", timeout=5000)
+            else:
+                logger.warning("[UI] Neither button nor menu trigger found")
+                return
 
-        await incognito_button_locator.wait_for(state="visible", timeout=10000)
+        # Status Check
+        button_classes = await incognito_locator.get_attribute("class") or ""
 
-        button_classes = await incognito_button_locator.get_attribute("class")
-
-        if button_classes and "ms-button-active" in button_classes:
+        if "ms-button-active" in button_classes:
             logger.debug("[UI] Temporary chat mode already active")
         else:
-            await incognito_button_locator.click(timeout=5000, force=True)
+            logger.debug("[UI] Enabling temporary chat mode")
+            await incognito_locator.click(timeout=5000, force=True)
             await asyncio.sleep(1)
 
-            updated_classes = await incognito_button_locator.get_attribute("class")
-            if updated_classes and "ms-button-active" in updated_classes:
-                logger.debug("[UI] Temporary chat mode enabled")
-            else:
-                logger.warning("[UI] Failed to enable temporary chat mode")
+        # Recovery: Close menu if still expanded
+        # Checking aria-expanded is more precise than a boolean flag
+        if await menu_trigger.get_attribute("aria-expanded") == "true":
+            logger.debug("[UI] Closing menu to restore UI state")
+            await page.keyboard.press("Escape")
 
     except asyncio.CancelledError:
         raise
     except Exception as e:
         logger.warning(f"[UI] Error in temporary chat mode: {e}")
+        # Final safety attempt to clear any stuck UI
+        if await menu_trigger.get_attribute("aria-expanded") == "true":
+            await page.keyboard.press("Escape")

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -161,7 +161,7 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
                 try:
                     logger.debug("[Model] Re-enabling temporary chat mode...")
                     incognito_button_locator = page.locator(
-                        'button[aria-label="Temporary chat toggle"]', 'button[aria-label="Toggle temporary chat"]'
+                        'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
                     )
 
                     await incognito_button_locator.wait_for(

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -161,8 +161,7 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
                 try:
                     logger.debug("[Model] Re-enabling temporary chat mode...")
                     incognito_button_locator = page.locator(
-                        'button[aria-label="Temporary chat toggle"]',
-                        'button[aria-label="Toggle temporary chat"]'
+                        'button[aria-label="Temporary chat toggle"]', 'button[aria-label="Toggle temporary chat"]'
                     )
 
                     await incognito_button_locator.wait_for(

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -162,7 +162,7 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
                     logger.debug("[Model] Re-enabling temporary chat mode...")
                     incognito_selector = 'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
                     menu_trigger_selector = 'button[aria-label="View more actions"]'
-                    
+
                     incognito_locator = page.locator(incognito_selector)
                     menu_trigger = page.locator(menu_trigger_selector)
 

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -160,41 +160,47 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
             if page_display_match:
                 try:
                     logger.debug("[Model] Re-enabling temporary chat mode...")
-                    incognito_button_locator = page.locator(
-                        'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
-                    )
+                    incognito_selector = 'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
+                    menu_trigger_selector = 'button[aria-label="View more actions"]'
+                    
+                    incognito_locator = page.locator(incognito_selector)
+                    menu_trigger = page.locator(menu_trigger_selector)
 
-                    await incognito_button_locator.wait_for(
-                        state="visible", timeout=5000
-                    )
+                    # Fast path: try to find the button directly
+                    try:
+                        await incognito_locator.wait_for(state="visible", timeout=3000)
+                    except Exception:
+                        # Fallback: check if it's inside the menu
+                        if await menu_trigger.is_visible():
+                            logger.debug("[Model] Button not visible, opening menu...")
+                            await menu_trigger.click()
+                            await incognito_locator.wait_for(state="visible", timeout=5000)
 
-                    button_classes = await incognito_button_locator.get_attribute(
-                        "class"
-                    )
+                    button_classes = await incognito_locator.get_attribute("class") or ""
 
-                    if button_classes and "ms-button-active" in button_classes:
+                    if "ms-button-active" in button_classes:
                         logger.debug("[Model] Temporary chat mode already active")
                     else:
                         logger.debug("[Model] Clicking to open temporary chat mode...")
-                        await incognito_button_locator.click(timeout=3000)
+                        await incognito_locator.click(timeout=3000, force=True)
                         await asyncio.sleep(0.5)
 
-                        updated_classes = await incognito_button_locator.get_attribute(
-                            "class"
-                        )
-                        if updated_classes and "ms-button-active" in updated_classes:
+                        updated_classes = await incognito_locator.get_attribute("class") or ""
+                        if "ms-button-active" in updated_classes:
                             logger.debug("[Model] Temporary chat mode enabled")
                         else:
-                            logger.warning(
-                                "Temporary chat mode state verification failed after click, may not have opened successfully."
-                            )
+                            logger.warning("[Model] Temporary chat mode state verification failed")
+
+                    # Recovery: Close menu if it remains open
+                    if await menu_trigger.get_attribute("aria-expanded") == "true":
+                        await page.keyboard.press("Escape")
 
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:
-                    logger.warning(
-                        f"Failed to re-enable temporary chat mode after model switching: {e}"
-                    )
+                    logger.warning(f"Failed to re-enable temporary chat mode after model switching: {e}")
+                    if await menu_trigger.get_attribute("aria-expanded") == "true":
+                        await page.keyboard.press("Escape")
 
                 # Invalidate function calling cache on model switch
                 try:

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -161,7 +161,8 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
                 try:
                     logger.debug("[Model] Re-enabling temporary chat mode...")
                     incognito_button_locator = page.locator(
-                        'button[aria-label="Temporary chat toggle"]'
+                        'button[aria-label="Temporary chat toggle"]',
+                        'button[aria-label="Toggle temporary chat"]'
                     )
 
                     await incognito_button_locator.wait_for(

--- a/browser_utils/models/switcher.py
+++ b/browser_utils/models/switcher.py
@@ -160,47 +160,20 @@ async def switch_ai_studio_model(page: AsyncPage, model_id: str, req_id: str) ->
             if page_display_match:
                 try:
                     logger.debug("[Model] Re-enabling temporary chat mode...")
-                    incognito_selector = 'button[aria-label="Temporary chat toggle"], button[aria-label="Toggle temporary chat"]'
-                    menu_trigger_selector = 'button[aria-label="View more actions"]'
+                    from browser_utils.initialization import enable_temporary_chat_mode
 
-                    incognito_locator = page.locator(incognito_selector)
-                    menu_trigger = page.locator(menu_trigger_selector)
-
-                    # Fast path: try to find the button directly
-                    try:
-                        await incognito_locator.wait_for(state="visible", timeout=3000)
-                    except Exception:
-                        # Fallback: check if it's inside the menu
-                        if await menu_trigger.is_visible():
-                            logger.debug("[Model] Button not visible, opening menu...")
-                            await menu_trigger.click()
-                            await incognito_locator.wait_for(state="visible", timeout=5000)
-
-                    button_classes = await incognito_locator.get_attribute("class") or ""
-
-                    if "ms-button-active" in button_classes:
-                        logger.debug("[Model] Temporary chat mode already active")
+                    enabled = await enable_temporary_chat_mode(page)
+                    if enabled:
+                        logger.debug("[Model] Temporary chat mode enabled or already active")
                     else:
-                        logger.debug("[Model] Clicking to open temporary chat mode...")
-                        await incognito_locator.click(timeout=3000, force=True)
-                        await asyncio.sleep(0.5)
-
-                        updated_classes = await incognito_locator.get_attribute("class") or ""
-                        if "ms-button-active" in updated_classes:
-                            logger.debug("[Model] Temporary chat mode enabled")
-                        else:
-                            logger.warning("[Model] Temporary chat mode state verification failed")
-
-                    # Recovery: Close menu if it remains open
-                    if await menu_trigger.get_attribute("aria-expanded") == "true":
-                        await page.keyboard.press("Escape")
+                        logger.warning(
+                            "[Model] Temporary chat mode state verification failed"
+                        )
 
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:
                     logger.warning(f"Failed to re-enable temporary chat mode after model switching: {e}")
-                    if await menu_trigger.get_attribute("aria-expanded") == "true":
-                        await page.keyboard.press("Escape")
 
                 # Invalidate function calling cache on model switch
                 try:


### PR DESCRIPTION
```
16:51:40.859 WRN SYS 13shv1v [UI] Error in temporary chat mode: Locator.wait_for: Timeout 10000ms exceeded.
Call log:
- waiting for locator("button[aria-label=\"Temporary chat toggle\"]") to be visible
```
<img width="367" height="256" alt="image" src="https://github.com/user-attachments/assets/2fdcba8f-3b11-4120-bebf-a1a0b6a01f0c" />
