### PR TITLE
Fix stuck on overlay

### DIFF
--- a/browser_utils/initialization/core.py
+++ b/browser_utils/initialization/core.py
@@ -586,6 +586,14 @@ async def _is_temporary_chat_active(page: AsyncPage) -> bool:
             except Exception:
                 continue
 
+        # New menu UI: active state is represented by a checkmark inside the menu item.
+        try:
+            checkmark_locator = page.locator("[data-test-incognito-checkmark]")
+            if await checkmark_locator.count() > 0:
+                return True
+        except Exception:
+            pass
+
         # Menu button variants (legacy and gray-release UI).
         toggle_locator = page.locator(
             "button[data-test-incognito-toggle], "
@@ -593,20 +601,6 @@ async def _is_temporary_chat_active(page: AsyncPage) -> bool:
             'button[aria-label="Toggle temporary chat"]'
         )
         if await toggle_locator.count() > 0:
-            # New UI: active state is represented by a checkmark inside the menu item.
-            try:
-                checkmark_locator = page.locator(
-                    "button[data-test-incognito-toggle] [data-test-incognito-checkmark], "
-                    'button[aria-label="Temporary chat toggle"] [data-test-incognito-checkmark], '
-                    'button[aria-label="Toggle temporary chat"] [data-test-incognito-checkmark]'
-                )
-                if (
-                    await checkmark_locator.count() > 0
-                ):
-                    return True
-            except Exception:
-                pass
-
             # Legacy/alternative signals.
             for attr_name in ("aria-pressed", "aria-checked"):
                 try:
@@ -656,6 +650,11 @@ async def enable_temporary_chat_mode(page: AsyncPage) -> bool:  # pragma: no cov
             pass
 
     try:
+        if await _is_temporary_chat_active(page):
+            logger.debug("[UI] Temporary chat mode already active")
+            await _close_menu_if_needed()
+            return True
+
         # Fast path
         logger.debug("[UI] Searching for temporary chat button (Fast path)")
         try:


### PR DESCRIPTION
```
16:39:12.140 ERR SYS d25rwck Error setting Thinking Level: Locator.click: Timeout 3000ms exceeded.
Call log:
- waiting for locator("[role=\"combobox\"][aria-label=\"Thinking Level\"], mat-select[aria-label=\"Thinking Level\"], [role=\"combobox\"][aria-label=\"Thinking level\"], mat-select[aria-label=\"Thinking level\"]")
- locator resolved to <mat-select tabindex="0" role="combobox" id="mat-select-0" aria-invalid="false" aria-expanded="false" aria-required="false" aria-disabled="false" class="mat-mdc-select" aria-haspopup="listbox" aria-label="Thinking Level" _ngcontent-ng-c2997479666="">…</mat-select>
- attempting click action
2 × waiting for element to be visible, enabled and stable
- element is visible, enabled and stable
- scrolling into view if needed
- done scrolling
- <div class="cdk-overlay-backdrop cdk-overlay-transparent-backdrop cdk-overlay-backdrop-showing"></div> from <div class="cdk-overlay-container">…</div> subtree intercepts pointer events
- retrying click action
- waiting 20ms
```
在上一个提交中，引入了打开```View more actions```的操作，执行这个操作后，在旧代码中无法正确识别当前temporary chat状态，或是可能识别到了temporary chat状态是已打开的状态，后续发送Escape因为某些原因失败，导致```View more actions```这个overlay一直处于打开状态，进而无法进行其它操作如上传文件/图片、设置thinking level等

该提交执行以下修复：
1. temporary chat状态判断前置，先判断当前temporary chat状态再选择是否要打开```View more actions```
2. 打开菜单后，无论后续判断或操作如何，最后都执行```_close_menu_if_needed()```尝试关闭overlay，避免卡住其它后续操作